### PR TITLE
Change Mobile Rig Guide to Googledoc

### DIFF
--- a/_site/audio/index.html
+++ b/_site/audio/index.html
@@ -345,7 +345,7 @@
         </li>
         
         <li>
-            <a href="/audio/mobile-rig-guide.html"> Mobile Rig User Guide</a>
+            <a href="https://docs.google.com/document/d/19e4lQLuMZR3f1oYEup3dKCXj9-n3ucjWrvn9TVsTThI/edit?usp=sharing"> Mobile Rig User Guide</a>
         </li>
         
         <li>


### PR DESCRIPTION
Change the Mobile Rig Guide from a html page to a google doc so it is easier to edit in the future (all the info in the html page has been copied over)